### PR TITLE
Fix store path resolution

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,8 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 export default class Store {
-  // TODO: try resolve('./store.json')
-  static #storePath = resolve(import.meta.dirname, 'store.json')
+  static #storePath = resolve('./src/store/store.json')
 
   static async get(property) {
     const store = await this.#getStore()


### PR DESCRIPTION
Correctly use Node's path.resolve function. `import.meta` is [set by the host environment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) and cannot be relied on when environments change. Relative paths can instead be directly used.