### PR TITLE
Move data store into persistent storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+# Local data store
+data/*
+
+# Framework temporary files
 node_modules/*
-src/store/store.json
 .yarn/*
+
+# Environment variables
 .env
 !.env.example
+
+# Local logs
 dump.rdb
 yarn-error.log

--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,10 @@ primary_region = 'ams'
   min_machines_running = 0
   processes = ['app']
 
+[mounts]
+source = 'ynabunq_volume'
+destination = '/app/data'
+
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "uuid": "^11.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,7 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 export default class Store {
-  static #storePath = resolve('./src/store/store.json')
+  static #storePath = resolve('./data/store.json')
 
   static async get(property) {
     const store = await this.#getStore()


### PR DESCRIPTION
* Use a data/ folder for store path instead of src/temp, src/store, etc.
* Add data/ folder to .gitignore (and add helpful comments to break down the file)
* Correctly mount volume on Fly.io to /app/data in order for data to persist between deployments
* Misc: let corepack create packageManager hash as part of switch to corepack